### PR TITLE
Feat/start

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -14,12 +14,16 @@ const LS_KEYS = {
 
 // Curated to avoid the feeds that are erroring at the source.
 const defaultFeeds = [
+    { title: 'Formula 1 Official', url: 'https://news.google.com/rss/search?q=site:formula1.com/en/latest&hl=en-GB&gl=GB&ceid=GB:en' },
     { title: 'Autosport (F1)', url: 'https://www.autosport.com/rss/f1/news/' },
     { title: 'Motorsport.com (F1)', url: 'https://www.motorsport.com/rss/f1/news/' },
     { title: 'RaceFans', url: 'https://feeds.feedburner.com/f1fanatic' },
     { title: 'FIA Press Releases', url: 'https://www.fia.com/rss/press-release' },
     { title: 'BBC Sport (F1)', url: 'https://feeds.bbci.co.uk/sport/formula1/rss.xml' },
+    { title: 'Sky News (F1)', url: 'https://news.google.com/rss/search?q=site:skysports.com/f1&hl=en-GB&gl=GB&ceid=GB:en' },
+    { title: 'ESPN (F1)', url: 'https://news.google.com/rss/search?q=site:espn.com/f1&hl=en-GB&gl=GB&ceid=GB:en\n' },
     { title: 'Grand Prix 247 (mirror)', url: 'https://news.google.com/rss/search?q=site:grandprix247.com&hl=en-GB&gl=GB&ceid=GB:en' },
+    { title: 'RaceFans', url: 'https://www.racefans.net/feed/' },
     // You can try these later if you like, but they often block proxies:
     // { title: 'PlanetF1', url: 'https://www.planetf1.com/feed/' },
     // { title: 'Grandprix.com', url: 'https://www.grandprix.com/rss.xml' },

--- a/js/app.js
+++ b/js/app.js
@@ -3,6 +3,8 @@
 // ===== Configuration & Storage =====
 const COOL_DOWN_MS = 30 * 60 * 1000; // 30 minutes
 const WORKER_BASE_DEFAULT = 'https://red-wood-fe7e.fallenangelbg.workers.dev/?url=';
+const MAX_ITEM_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 1 week
+const ENRICH_NON_GNEWS = true; // also enrich non-GNews items that lack images
 
 const LS_KEYS = {
     FEEDS: 'f1Feeds',
@@ -21,9 +23,8 @@ const defaultFeeds = [
     { title: 'FIA Press Releases', url: 'https://www.fia.com/rss/press-release' },
     { title: 'BBC Sport (F1)', url: 'https://feeds.bbci.co.uk/sport/formula1/rss.xml' },
     { title: 'Sky News (F1)', url: 'https://news.google.com/rss/search?q=site:skysports.com/f1&hl=en-GB&gl=GB&ceid=GB:en' },
-    { title: 'ESPN (F1)', url: 'https://news.google.com/rss/search?q=site:espn.com/f1&hl=en-GB&gl=GB&ceid=GB:en\n' },
+    { title: 'ESPN (F1)', url: 'https://news.google.com/rss/search?q=site:espn.com/f1&hl=en-GB&gl=GB&ceid=GB:en' },
     { title: 'Grand Prix 247 (mirror)', url: 'https://news.google.com/rss/search?q=site:grandprix247.com&hl=en-GB&gl=GB&ceid=GB:en' },
-    { title: 'RaceFans', url: 'https://www.racefans.net/feed/' },
     // You can try these later if you like, but they often block proxies:
     // { title: 'PlanetF1', url: 'https://www.planetf1.com/feed/' },
     // { title: 'Grandprix.com', url: 'https://www.grandprix.com/rss.xml' },
@@ -38,6 +39,8 @@ let articles = loadJSON(LS_KEYS.ARTICLES, {});
 let lastVisit = Number(localStorage.getItem(LS_KEYS.LAST_VISIT) || 0);
 let lastFetch = loadJSON(LS_KEYS.LAST_FETCH, {});
 let proxyBase = localStorage.getItem(LS_KEYS.PROXY_BASE) || WORKER_BASE_DEFAULT; // default to your Worker
+
+pruneOldAndSanitize();
 
 // ===== Proxy builder & RSS fetch =====
 function buildProxyUrl(url) {
@@ -57,9 +60,7 @@ async function fetchRSS(url) {
         throw new Error(`Network error: ${e.message}`);
     }
 
-    if (!res.ok) {
-        throw new Error(`HTTP ${res.status} from source`);
-    }
+    if (!res.ok) throw new Error(`HTTP ${res.status} from source`);
 
     let text = await res.text();
     const ct = (res.headers.get('content-type') || '').toLowerCase();
@@ -187,7 +188,45 @@ function getImageFromItem(item, baseForRel) {
     return null;
 }
 
-// ===== Core fetch per feed =====
+// Identify "generic" Google thumbs we want to replace
+function isGoogleGenericThumb(imgUrl) {
+    if (!imgUrl || typeof imgUrl !== 'string') return false;
+    try {
+        const u = new URL(imgUrl, 'https://news.google.com'); // tolerate schemeless
+        const host = u.host.toLowerCase();
+        const path = u.pathname.toLowerCase();
+
+        // Any google cache/CDN host → treat as generic
+        if (host.includes('googleusercontent.com')) return true;    // lh3.googleusercontent.com etc.
+        if (host.includes('gstatic.com')) return true;              // encrypted-tbn*.gstatic.com etc.
+        if (host.includes('news.google.com')) return true;          // direct news assets/cached thumbs
+
+        // Common Google branding/static paths
+        if (path.includes('/news/static/')) return true;
+        if (path.includes('/img/branding')) return true;
+        if (path.includes('google_news')) return true;
+        return false;
+    } catch {
+        // As a last resort, a substring test (handles weird relative values)
+        return /googleusercontent\.com|gstatic\.com|news\.google\.com|google_news|\/img\/branding/i.test(imgUrl);
+    }
+}
+
+// Prune >1 week and sanitize stored Google thumbs to null
+function pruneOldAndSanitize() {
+    const now = Date.now();
+    let changed = false;
+    for (const [id, a] of Object.entries(articles)) {
+        const t = Date.parse(a.pubDate || 0) || 0;
+        if (!t || (now - t) > MAX_ITEM_AGE_MS) { delete articles[id]; changed = true; continue; }
+        if (isGoogleNewsFeed(a.feedUrl) && a.image && isGoogleGenericThumb(a.image)) {
+            a.image = null; changed = true;      // force lazy enrichment
+        }
+    }
+    if (changed) saveJSON(LS_KEYS.ARTICLES, articles);
+}
+
+// ===== Core fetch per feed (with Google-thumbs cleanup & 1-week filter) =====
 async function updateFromFeed(feed) {
     const now = Date.now();
     const last = lastFetch[feed.url] || 0;
@@ -202,25 +241,7 @@ async function updateFromFeed(feed) {
             let title = sanitize(item.querySelector('title')?.textContent);
             const rawLinkEl = item.querySelector('link');
             const rawLink = rawLinkEl?.getAttribute?.('href') || rawLinkEl?.textContent || '';
-
-            // Base description (plain text)
-            const descriptionNode = item.querySelector('description, summary, content\\:encoded');
-            let descriptionHtml = descriptionNode?.textContent || '';
-            let description = toPlainText(descriptionHtml);
-
-            // Prefer origin link for Google News if we can infer it from description
-            let link = resolveUrl(rawLink, feed.url);
-            if (gnews) {
-                const g = extractOriginalFromGoogleDescription(descriptionHtml);
-                if (g.link) link = resolveUrl(g.link, feed.url);
-                title = cleanGoogleNewsTitle(title);
-                description = g.text; // already plain text
-            }
-
-            const guid =
-                item.querySelector('guid')?.textContent ||
-                item.querySelector('id')?.textContent || // Atom
-                '';
+            const guid = item.querySelector('guid')?.textContent || item.querySelector('id')?.textContent || '';
 
             const pubDate =
                 item.querySelector('pubDate')?.textContent ||
@@ -228,7 +249,23 @@ async function updateFromFeed(feed) {
                 item.querySelector('published')?.textContent ||
                 new Date().toISOString();
 
-            const image = getImageFromItem(item, link || feed.url);
+            const pubMs = Date.parse(pubDate) || now;
+            if ((now - pubMs) > MAX_ITEM_AGE_MS) continue; // too old
+
+            const descriptionNode = item.querySelector('description, summary, content\\:encoded');
+            let descriptionHtml = descriptionNode?.textContent || '';
+            let description = toPlainText(descriptionHtml);
+
+            let link = resolveUrl(rawLink, feed.url);
+            if (gnews) {
+                const g = extractOriginalFromGoogleDescription(descriptionHtml);
+                if (g.link) link = resolveUrl(g.link, feed.url);
+                title = cleanGoogleNewsTitle(title);
+                description = g.text;
+            }
+
+            let image = getImageFromItem(item, link || feed.url);
+            if (gnews && image && isGoogleGenericThumb(image)) image = null;
 
             const id = makeId(feed.url, link, guid);
             if (!articles[id]) {
@@ -239,6 +276,7 @@ async function updateFromFeed(feed) {
                 added++;
             }
         }
+
         lastFetch[feed.url] = now;
         saveJSON(LS_KEYS.LAST_FETCH, lastFetch);
         saveJSON(LS_KEYS.ARTICLES, articles);
@@ -259,7 +297,10 @@ async function refreshAll() {
         const errors = results
             .filter(r => r.status === 'fulfilled' && r.value.error)
             .map(r => r.value.error);
+
+        pruneOldAndSanitize();
         render();
+
         toast(`Fetched. ${totalAdded} new article${totalAdded !== 1 ? 's' : ''}.`);
         if (errors.length) toast(errors.join('<br>'), true);
     } catch (e) {
@@ -319,6 +360,8 @@ function renderArticles() {
     emptyState.classList.add('d-none');
 
     let newCount = 0;
+    const needObserve = [];
+
     for (const a of items) {
         const isNew = !a.seen && new Date(a.pubDate).getTime() > (lastVisit || 0);
         if (isNew) newCount++;
@@ -326,16 +369,40 @@ function renderArticles() {
         col.className = 'col-12 col-md-6 col-lg-4';
         col.innerHTML = articleCardHTML(a, isNew);
         grid.appendChild(col);
+
+        // Decide whether we need to lazy-enrich this card
+        const isG = isGoogleNewsFeed(a.feedUrl);
+        let effectiveImage = a.image || null;
+        if (isG && effectiveImage && isGoogleGenericThumb(effectiveImage)) {
+            effectiveImage = null; // force placeholder + lazy
+        }
+        if ((isG || ENRICH_NON_GNEWS) && !effectiveImage) {
+            needObserve.push(a.id);
+        }
     }
     newCountBadge.textContent = `${newCount} new`;
+
+    // setup observer and register placeholders
+    setupCardObserver();
+    for (const id of needObserve) observeCardForLazy(id);
 }
 
 function articleCardHTML(a, isNew) {
-    const img = a.image ? `<img src="${a.image}" class="card-img-top" alt="" onerror="this.remove()">` : '';
+    const isG = isGoogleNewsFeed(a.feedUrl);
+    let effectiveImage = a.image || null;
+    // Extra guard right before rendering:
+    if (!effectiveImage || (isG && isGoogleGenericThumb(effectiveImage))) {
+        effectiveImage = null;
+    }
+
+    const imgHTML = effectiveImage
+        ? `<img src="${effectiveImage}" class="card-img-top" alt="" onerror="this.remove()">`
+        : `<div class="image-holder w-100 ratio ratio-16x9 bg-secondary-subtle" data-id="${a.id}" style="min-height: 140px;"></div>`;
+
     const date = new Date(a.pubDate);
     return `
   <div class="card h-100 ${isNew ? 'article-new' : ''}">
-    ${img}
+    ${imgHTML}
     <div class="card-body d-flex flex-column">
       <div class="d-flex align-items-center mb-2">
         <span class="badge bg-info-subtle text-info-emphasis badge-feed me-2">${a.feedTitle}</span>
@@ -349,6 +416,145 @@ function articleCardHTML(a, isNew) {
       </div>
     </div>
   </div>`;
+}
+
+// ===== Lazy image enrichment =====
+
+// Concurrency-limited queue
+const LAZY_MAX_CONCURRENCY = 2;
+const LAZY_FETCH_TIMEOUT_MS = 8000; // conservative
+let lazyInFlight = 0;
+const lazyQueue = [];
+const lazyAttempted = new Set();   // id set: avoid repeats per session
+
+function timeoutPromise(ms) {
+    return new Promise((_, rej) => setTimeout(() => rej(new Error('Timeout')), ms));
+}
+
+function extractImageFromHTML(html) {
+    // Meta tags
+    const patterns = [
+        /<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["'][^>]*>/i,
+        /<meta[^>]+name=["']og:image["'][^>]+content=["']([^"']+)["'][^>]*>/i,
+        /<meta[^>]+name=["']twitter:image["'][^>]+content=["']([^"']+)["'][^>]*>/i,
+        /<meta[^>]+property=["']twitter:image["'][^>]+content=["']([^"']+)["'][^>]*>/i,
+        /<link[^>]+rel=["']image_src["'][^>]+href=["']([^"']+)["'][^>]*>/i,
+        /<meta[^>]+property=["']og:image:url["'][^>]+content=["']([^"']+)["'][^>]*>/i,
+    ];
+    for (const re of patterns) {
+        const m = html.match(re);
+        if (m && m[1]) return m[1];
+    }
+
+    // JSON-LD "image"
+    try {
+        const ldMatches = html.match(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi) || [];
+        for (const block of ldMatches) {
+            const json = block.replace(/^<script[^>]*>/i, '').replace(/<\/script>$/i, '');
+            const obj = JSON.parse(json);
+            const candidates = Array.isArray(obj) ? obj : [obj];
+            for (const o of candidates) {
+                const image = o?.image;
+                if (typeof image === 'string') return image;
+                if (Array.isArray(image) && image.length) return image[0];
+                if (image && typeof image === 'object' && image.url) return image.url;
+            }
+        }
+    } catch (_) {}
+
+    // First <img src>
+    const imgMatch = html.match(/<img[^>]+src=["']([^"']+)["'][^>]*>/i);
+    if (imgMatch && imgMatch[1]) return imgMatch[1];
+
+    return null;
+}
+
+async function fetchOGImageViaProxy(articleUrl) {
+    const proxied = buildProxyUrl(articleUrl);
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), LAZY_FETCH_TIMEOUT_MS);
+    try {
+        const resp = await Promise.race([
+            fetch(proxied, { cache: 'no-store', redirect: 'follow', signal: controller.signal }),
+            timeoutPromise(LAZY_FETCH_TIMEOUT_MS)
+        ]);
+        if (!resp || !resp.ok) throw new Error(`HTTP ${resp?.status || 'ERR'}`);
+        const ct = (resp.headers.get('content-type') || '').toLowerCase();
+        if (!/html|text\/plain/.test(ct)) throw new Error('Non-HTML');
+        const html = await resp.text();
+        return extractImageFromHTML(html);
+    } finally {
+        clearTimeout(t);
+    }
+}
+
+async function processLazyJob(id) {
+    if (lazyAttempted.has(id)) return;
+    lazyAttempted.add(id);
+
+    const a = articles[id];
+    if (!a) return;
+
+    const isG = isGoogleNewsFeed(a.feedUrl);
+    // If an image exists AND it's not a Google generic thumb, skip.
+    if (a.image && !(isG && isGoogleGenericThumb(a.image))) return;
+    if (!isG && !ENRICH_NON_GNEWS) return;
+    if (!a.link) return;
+
+    try {
+        const img = await fetchOGImageViaProxy(a.link);
+        if (img) {
+            a.image = resolveUrl(img, a.link);
+            saveJSON(LS_KEYS.ARTICLES, articles);
+            // Update the DOM card if it's currently rendered
+            const holder = document.querySelector(`.image-holder[data-id="${id}"]`);
+            if (holder) {
+                const imgEl = document.createElement('img');
+                imgEl.className = 'card-img-top';
+                imgEl.alt = '';
+                imgEl.src = a.image;
+                imgEl.onerror = () => imgEl.remove();
+                holder.replaceWith(imgEl);
+            }
+        }
+    } catch (_) {
+        // Silently ignore to keep UI smooth
+    }
+}
+
+function pumpLazyQueue() {
+    while (lazyInFlight < LAZY_MAX_CONCURRENCY && lazyQueue.length) {
+        const id = lazyQueue.shift();
+        lazyInFlight++;
+        processLazyJob(id).finally(() => {
+            lazyInFlight--;
+            pumpLazyQueue();
+        });
+    }
+}
+
+// IntersectionObserver to enqueue visible cards without images
+let cardObserver = null;
+function setupCardObserver() {
+    if (cardObserver) cardObserver.disconnect();
+    cardObserver = new IntersectionObserver((entries) => {
+        for (const e of entries) {
+            if (e.isIntersecting) {
+                const el = e.target;
+                const id = el.getAttribute('data-id');
+                if (id && !lazyAttempted.has(id)) {
+                    lazyQueue.push(id);
+                    pumpLazyQueue();
+                }
+                cardObserver.unobserve(el);
+            }
+        }
+    }, { root: null, rootMargin: '200px', threshold: 0.01 }); // start a bit before visible
+}
+
+function observeCardForLazy(id) {
+    const ph = document.querySelector(`.image-holder[data-id="${id}"]`);
+    if (ph) cardObserver.observe(ph);
 }
 
 // Expose for inline handler


### PR DESCRIPTION
This pull request introduces improvements to how article images are handled and stored, particularly for Google News feeds, and adds a lazy enrichment system for articles lacking high-quality images. The changes help ensure that articles display better images, avoid generic Google thumbnails, and prune old articles to keep the feed fresh and relevant.

**Image handling and enrichment:**

* Added detection of "generic" Google thumbnails and logic to remove them from stored articles, forcing lazy enrichment with better images.
* Implemented a lazy image enrichment system that fetches Open Graph/Twitter images from article pages via a proxy, updating cards in the UI as images become available. This uses concurrency control and IntersectionObserver for efficiency.

**Article storage and pruning:**

* Articles older than one week are now pruned from local storage, and Google News articles with generic thumbnails are sanitized to trigger image enrichment. [[1]](diffhunk://#diff-32cdce28ac549728f6a28999f6d874aa4f29e6da1406c28c3134cd8d421a866aR6-R7) [[2]](diffhunk://#diff-32cdce28ac549728f6a28999f6d874aa4f29e6da1406c28c3134cd8d421a866aL186-R229) [[3]](diffhunk://#diff-32cdce28ac549728f6a28999f6d874aa4f29e6da1406c28c3134cd8d421a866aR43-R44) [[4]](diffhunk://#diff-32cdce28ac549728f6a28999f6d874aa4f29e6da1406c28c3134cd8d421a866aR300-R303)

**Feed configuration:**

* Added new default feeds for Formula 1 Official, Sky News (F1), and ESPN (F1) to the feed list.

**Rendering improvements:**

* Updated the article rendering logic to use placeholders for missing images and trigger lazy enrichment when needed, improving the visual quality of the feed.

**Core fetch logic:**

* Improved per-feed fetch logic to skip articles older than one week and sanitize Google News thumbnails before storage. [[1]](diffhunk://#diff-32cdce28ac549728f6a28999f6d874aa4f29e6da1406c28c3134cd8d421a866aR244-R268) [[2]](diffhunk://#diff-32cdce28ac549728f6a28999f6d874aa4f29e6da1406c28c3134cd8d421a866aR279)